### PR TITLE
Schedule batch commands API

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ elixir:
   - 1.5.2
 
 otp_release:
-  - 20.1
+  - 20.2
 
 services:
   - postgresql

--- a/config/config.exs
+++ b/config/config.exs
@@ -6,4 +6,4 @@ config :commanded_scheduler,
   max_retries: 3,
   job_timeout: :infinity
 
-import_config "#{Mix.env}.exs"
+import_config "#{Mix.env()}.exs"

--- a/lib/commanded/scheduler/batch.ex
+++ b/lib/commanded/scheduler/batch.ex
@@ -1,0 +1,38 @@
+defmodule Commanded.Scheduler.Batch do
+  @moduledoc """
+  Schedule a batch of one-off commands due at their given date/time (in UTC).
+  """
+
+  alias Commanded.Scheduler.ScheduleBatch
+
+  def new(schedule_uuid) do
+    %ScheduleBatch{schedule_uuid: schedule_uuid}
+  end
+
+  def schedule_once(%ScheduleBatch{} = batch, command, due_at, opts \\ []) do
+    %ScheduleBatch{schedule_once: schedule_once} = batch
+
+    once = %ScheduleBatch.Once{
+      name: name(opts),
+      command: command,
+      due_at: due_at
+    }
+
+    %ScheduleBatch{batch | schedule_once: [once | schedule_once]}
+  end
+
+  def schedule_recurring(%ScheduleBatch{} = batch, command, cron_expression, opts \\ [])
+      when is_bitstring(cron_expression) do
+    %ScheduleBatch{schedule_recurring: schedule_recurring} = batch
+
+    recurring = %ScheduleBatch.Recurring{
+      name: name(opts),
+      command: command,
+      schedule: cron_expression
+    }
+
+    %ScheduleBatch{batch | schedule_recurring: [recurring | schedule_recurring]}
+  end
+
+  defp name(opts), do: Keyword.get(opts, :name)
+end

--- a/lib/commanded/scheduler/schedule/schedule.ex
+++ b/lib/commanded/scheduler/schedule/schedule.ex
@@ -2,8 +2,8 @@ defmodule Commanded.Scheduler.Schedule do
   @moduledoc false
 
   alias Commanded.Scheduler.{
-    CancelSchedule,
     ScheduleBatch,
+    CancelSchedule,
     ScheduleCancelled,
     ScheduledOnce,
     ScheduledRecurring,

--- a/lib/commanded/scheduler/schedule/schedule_batch.ex
+++ b/lib/commanded/scheduler/schedule/schedule_batch.ex
@@ -1,14 +1,17 @@
 defmodule Commanded.Scheduler.ScheduleBatch do
   @moduledoc """
-  Schedule a batch of one-off commands due at their given date/time (in UTC).
+  Schedule a batch of one-off and recurring commands.
   """
 
   defmodule Once do
+    @moduledoc false
+
     @type t :: %__MODULE__{
             name: String.t(),
             command: struct(),
             due_at: DateTime.t() | NaiveDateTime.t()
           }
+
     defstruct [
       :name,
       :command,
@@ -17,11 +20,14 @@ defmodule Commanded.Scheduler.ScheduleBatch do
   end
 
   defmodule Recurring do
+    @moduledoc false
+
     @type t :: %__MODULE__{
             name: String.t(),
             command: struct(),
             schedule: String.t()
           }
+
     defstruct [
       :name,
       :command,
@@ -34,6 +40,7 @@ defmodule Commanded.Scheduler.ScheduleBatch do
           schedule_once: [Once.t()],
           schedule_recurring: [Recurring.t()]
         }
+
   defstruct [
     :schedule_uuid,
     schedule_once: [],

--- a/lib/commanded/scheduler/scheduling/projection.ex
+++ b/lib/commanded/scheduler/scheduling/projection.ex
@@ -22,6 +22,7 @@ defmodule Commanded.Scheduler.Projection do
   end
 
   alias Commanded.Scheduler.{
+    ScheduleCancelled,
     ScheduledOnce,
     ScheduledRecurring,
     ScheduleTriggered,
@@ -62,6 +63,10 @@ defmodule Commanded.Scheduler.Projection do
       command_type: command_type,
       schedule: schedule,
     })
+  end
+
+  project %ScheduleCancelled{schedule_uuid: schedule_uuid, name: name} do
+    Ecto.Multi.delete_all(multi, :schedule, schedule_query(schedule_uuid, name))
   end
 
   project %ScheduleTriggered{schedule_uuid: schedule_uuid, name: name} do

--- a/test/scheduler/jobs/jobs_test.exs
+++ b/test/scheduler/jobs/jobs_test.exs
@@ -42,6 +42,15 @@ defmodule Commanded.JobsTest do
       assert Jobs.scheduled_jobs() |> length() == 1
     end
 
+    test "should not be pending job until due at", %{run_at: run_at} do
+      past = NaiveDateTime.add(run_at, -60, :second)
+      future = NaiveDateTime.add(run_at, 60, :second)
+
+      assert Jobs.pending_jobs(past) == []
+      assert Jobs.pending_jobs(run_at) != []
+      assert Jobs.pending_jobs(future) != []
+    end
+
     test "should execute job after run at time elapses", %{run_at: run_at} do
       # execute pending jobs at the given "now" date/time
       Jobs.run_jobs(run_at)

--- a/test/scheduling/dispatcher_test.exs
+++ b/test/scheduling/dispatcher_test.exs
@@ -4,8 +4,7 @@ defmodule Commanded.Scheduling.DispatcherTest do
   import Commanded.Assertions.EventAssertions
   import Commanded.Scheduler.Factory
 
-  alias Commanded.Helpers.Wait
-  alias Commanded.Scheduler.{Dispatcher, Jobs, ScheduleTriggered, TriggerSchedule}
+  alias Commanded.Scheduler.{Dispatcher, ScheduleTriggered, TriggerSchedule}
 
   describe "dispatcher" do
     setup [:schedule_once, :trigger_schedule]
@@ -37,12 +36,6 @@ defmodule Commanded.Scheduling.DispatcherTest do
     end
 
     test "should execute dispatch as scheduled job", context do
-      now = NaiveDateTime.utc_now()
-
-      Wait.until(fn -> assert Jobs.scheduled_jobs() != [] end)
-
-      assert :ok = Jobs.run_jobs(now)
-
       assert_receive_event(ScheduleTriggered, fn event ->
         assert event.schedule_uuid == context.schedule_uuid
       end)

--- a/test/support/factory.ex
+++ b/test/support/factory.ex
@@ -11,7 +11,7 @@ defmodule Commanded.Scheduler.Factory do
     schedule_uuid = UUID.uuid4()
     schedule_name = "timeout_reservation"
     ticket_uuid = Map.get(context, :ticket_uuid, UUID.uuid4())
-    due_at = NaiveDateTime.utc_now()
+    due_at = NaiveDateTime.utc_now() |> NaiveDateTime.add(60, :second)
 
     command = %TimeoutReservation{
       ticket_uuid: ticket_uuid

--- a/test/support/factory.ex
+++ b/test/support/factory.ex
@@ -11,7 +11,7 @@ defmodule Commanded.Scheduler.Factory do
     schedule_uuid = UUID.uuid4()
     schedule_name = "timeout_reservation"
     ticket_uuid = Map.get(context, :ticket_uuid, UUID.uuid4())
-    due_at = NaiveDateTime.utc_now() |> NaiveDateTime.add(60, :second)
+    due_at = NaiveDateTime.utc_now() |> add_minutes(10)
 
     command = %TimeoutReservation{
       ticket_uuid: ticket_uuid
@@ -89,7 +89,7 @@ defmodule Commanded.Scheduler.Factory do
 
   def reserve_ticket(context) do
     ticket_uuid = Map.get(context, :ticket_uuid) || UUID.uuid4()
-    expires_at = NaiveDateTime.add(NaiveDateTime.utc_now(), 60, :second)
+    expires_at = NaiveDateTime.utc_now() |> add_minutes(10)
 
     reserve_ticket = %ReserveTicket{
       ticket_uuid: ticket_uuid,
@@ -107,5 +107,9 @@ defmodule Commanded.Scheduler.Factory do
       expires_at: expires_at,
       due_at: expires_at
     ]
+  end
+
+  defp add_minutes(date, minutes) do
+    NaiveDateTime.add(date, 60 * minutes, :second)
   end
 end

--- a/test/support/runtime_case.ex
+++ b/test/support/runtime_case.ex
@@ -8,10 +8,20 @@ defmodule Commanded.Scheduler.RuntimeCase do
   alias Commanded.Scheduler.Repo
   alias Commanded.Serialization.JsonSerializer
 
-  setup do
+  setup_all do
+    database_config = Application.get_env(:commanded_scheduler, Repo)
+
+    Application.ensure_all_started(:postgrex)
+
+    {:ok, conn} = Postgrex.start_link(database_config)
+
+    [conn: conn]
+  end
+
+  setup %{conn: conn} do
     {:ok, event_store} = InMemory.start_link(serializer: JsonSerializer)
 
-    reset_database()
+    reset_database(conn)
 
     Application.ensure_all_started(:commanded)
     Application.ensure_all_started(:commanded_scheduler)
@@ -26,22 +36,16 @@ defmodule Commanded.Scheduler.RuntimeCase do
     :ok
   end
 
-  defp reset_database do
-    database_config = Application.get_env(:commanded_scheduler, Repo)
-
-    Application.ensure_all_started(:postgrex)
-
-    with {:ok, conn} <- Postgrex.start_link(database_config) do
-      Postgrex.query!(
-        conn,
-        """
-          TRUNCATE TABLE
-            projection_versions,
-            schedules
-          RESTART IDENTITY;
-        """,
-        []
-      )
-    end
+  defp reset_database(conn) do
+    Postgrex.query!(
+      conn,
+      """
+        TRUNCATE TABLE
+          projection_versions,
+          schedules
+        RESTART IDENTITY;
+      """,
+      []
+    )
   end
 end


### PR DESCRIPTION
Add a new `Scheduler.Batch` module to construct a batch of scheduled commands:

```elixir
alias Commanded.Scheduler.Batch

batch =
  reservation_id
  |> Batch.new()
  |> Batch.schedule_once(%TimeoutReservation{..}, timeout_due_at, name: "timeout")
  |> Batch.schedule_once(%ReleaseSeat{..}, release_due_at, name: "release")
```

Then schedule the batch:

```elixir
Commanded.Scheduler.schedule_batch(batch)
```

Fixes #5.